### PR TITLE
Fix install failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   ],
   "dependencies": {
-    "spaces-ng": "git+https://github.com/ThreatConnect-Inc/spaces-ng.git#feature/ng-4"
+    "spaces-ng": "ThreatConnect-Inc/spaces-ng#feature/ng-4"
   },
   "description": "ThreatConnect SDK for Angular.",
   "devDependencies": {


### PR DESCRIPTION
When trying to install a application with `threatconnect-ng` as dependency, i get

```bash
$ yarn install
yarn install v1.0.1
[1/4] Resolving packages...
[2/4] Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads https://github.com/ThreatConnect-Inc/spaces-ng.git
Directory: <app-directory>
Output:
```

And with `npm` i got

```bash
$ npm install
npm ERR! Error while executing:
npm ERR! <bash-directory> ls-remote -h -t https://github.com/ThreatConnect-Inc/spaces-ng.git
npm ERR!
npm ERR!
npm ERR! exited with error code: 128
npm ERR! A complete log of this run can be found in:
npm ERR!     <log-path>
```

This was fixed by not using http as dependency source.
